### PR TITLE
Adding team-shared CLion files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,23 @@ UnitTests/
 open-builder-unit-tests/
 
 # Clion
-.idea
-cmake-build*
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# CMake
+cmake-build-*/

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+    <code_scheme name="Project" version="173">
+        <clangFormatSettings>
+            <option name="ENABLED" value="true"/>
+        </clangFormatSettings>
+    </code_scheme>z
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+  <component name="CidrRootsConfiguration">
+    <sourceRoots>
+      <file path="$PROJECT_DIR$/scripts" />
+      <file path="$PROJECT_DIR$/shaders" />
+      <file path="$PROJECT_DIR$/src" />
+    </sourceRoots>
+  </component>
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/open-builder.iml" filepath="$PROJECT_DIR$/.idea/open-builder.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/open-builder.iml
+++ b/.idea/open-builder.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Hey! I've checked your [PR](https://github.com/Hopson97/open-builder/pull/34) for CLion support in open-builder.  
I thought it'd be nice to also update the .gitignore to include a couple files that JetBrains recommend to team-share.
Template used is from the [gitignore plugin](https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore).
This allows some cool stuff like mark specific directories as source, adding custom team-shared configurations, etc.
Here is the end result:
![](http://people-using-python.needs-to-s.top/4wQeSc5.png)